### PR TITLE
Fix broken express dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dependencies" : {
         "base62" : "*",
         "express-params" : "*",
-        "express" : "*",
+        "express" : "~3.5.1",
         "optimist" : "*",
         "q" : "*",
         "sqlite3" : "*"


### PR DESCRIPTION
This is not compatible with express 4.0.0, so the dependency has to be stricter.
